### PR TITLE
Fix typos in require('lib/airport') and regexp for signal_level

### DIFF
--- a/examples/geolocation.js
+++ b/examples/geolocation.js
@@ -1,6 +1,6 @@
 var querystring = require('querystring');
 var https = require('https');
-var wifiscanner = require('./wifiscanner.js');
+var wifiscanner = require('../lib/wifiscanner.js');
 
 function buildRequestOptions(cells) {
     var maxCells = 10;

--- a/examples/scanner.js
+++ b/examples/scanner.js
@@ -1,4 +1,4 @@
-var wifiscanner = require('./wifiscanner.js');
+var wifiscanner = require('../lib/wifiscanner.js');
 
 wifiscanner.scan(function(err, data){
 	if (err) {

--- a/lib/iwlist.js
+++ b/lib/iwlist.js
@@ -16,7 +16,7 @@ function parseIwlist(str) {
         // 'encryption_key' : /Encryption key:(.*)/,
         // 'bitrates' : /Bit Rates:(.*)/,
         // 'quality' : /Quality(?:=|\:)([^\s]+)/,
-        'signal_level' : /Signal level(?:=|\:)([\w]+)/
+        'signal_level' : /Signal level(?:=|\:)([-\w]+)/
     };
 
     for (var i=0,l=out.length; i<l; i++) {

--- a/lib/wifiscanner.js
+++ b/lib/wifiscanner.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
-var airport = require('lib/airport');
-var iwlist = require('lib/iwlist');
+var airport = require('./airport');
+var iwlist = require('./iwlist');
 
 function scan(callback) {
     fs.exists(airport.utility, function (exists) {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version" : "0.0.1",
     "description" : "Scan surrounding WiFi access points",
     "author": "Maurice Svay <maurice@svay.com>",
-    "main": "./wifiscanner",
+    "main": "./lib/wifiscanner",
     "repository": {
         "type": "git",
         "url": "git://https://github.com/mauricesvay/node-wifiscanner.git"


### PR DESCRIPTION
Hello Maurice,

This patch fixed two typos in wifiscanner.js and lib/iwlist.js. Namely,
- In wifiscanner.js, changed `require('/lib/airport')` to `require('./airport')` and  `require('/lib/iwlist')` to `require('./iwlist')` to make it work properly.
- In iwlist.js, fixed `'signal_level' : /Signal level(?:=|\:)([-\w]+)/` so that it works with negative signal levels.
- Restructured the codebase so that it looks neater. wifiscanner.js is moved to lib/, and scanner.js and geolocation.js are moved into examples/ . package.json is updated to reflect this change.

Also I can't find this project on npm, would be great if you can publish it. That's all. Thanks.

Regards,
xkxx.
