### PR TITLE
Forcing LANG of iwlist, fixed callback name

### DIFF
--- a/lib/iwlist.js
+++ b/lib/iwlist.js
@@ -1,4 +1,5 @@
 var exec = require('child_process').exec;
+var util = require('util');
 var linuxProvider = '/sbin/iwlist';
 
 function parseIwlist(str) {
@@ -48,10 +49,11 @@ function parseIwlist(str) {
     return cells;
 }
 
-function scan(callback){
-    exec(linuxProvider + ' scan', function(err, stdout, stderr){
+function scan(callback) {
+    var new_env = util._extend(process.env, { LANG: "en" });
+    exec(linuxProvider + ' scan', new_env, function (err, stdout, stderr) {
         if (err) {
-            errClbk(err, null);
+            callback(err, null);
             return;
         }
         callback(null, parseIwlist(stdout));


### PR DESCRIPTION
Forcing language of iwlist to be English, in order to avoid regexp issues
Fixing name of callback function in case of error
