### PR TITLE
Update airport.js to use `airport scan`

### DIFF
--- a/lib/airport.js
+++ b/lib/airport.js
@@ -26,7 +26,7 @@ function parseAirport(str) {
 }
 
 function scan(callback) {
-    exec(macProvider + ' -s', function(err, stdout, stderr){
+    exec(macProvider + ' scan', function(err, stdout, stderr){
         if (err) {
             callback(err, null);
             return;


### PR DESCRIPTION
`airport -s` seems to be spotty on 10.9. It works fine on 10.10, but `airport scan` works on both.