### PR TITLE
Use proper errors in callbacks

### DIFF
--- a/lib/wifiscanner.js
+++ b/lib/wifiscanner.js
@@ -22,7 +22,7 @@ function scan(callback) {
                     return;
                 }
 
-                callback("No scanning utility found", null);
+                callback(new Error("No scanning utility found"), null);
             });
         });
     });


### PR DESCRIPTION
It's important to always use proper Error objects as the first argument in callbacks.