### PR TITLE
Compensation for double byte chars in ssid

### DIFF
--- a/lib/airport.js
+++ b/lib/airport.js
@@ -1,6 +1,17 @@
 var exec = require('child_process').exec;
 var macProvider = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport';
 
+function byteLength(str) {
+    // returns the byte length of an utf8 string
+    var s = str.length;
+    for (var i=str.length-1; i>=0; i--) {
+      var code = str.charCodeAt(i);
+      if (code > 0x7f && code <= 0x7ff) s++;
+      else if (code > 0x7ff && code <= 0xffff) s+=2;
+    }
+    return s;
+}
+
 function parseAirport(str) {
     var lines = str.split('\n');
     var colSsid = 0;
@@ -13,12 +24,13 @@ function parseAirport(str) {
 
     var wifis = [];
     for (var i=1,l=lines.length; i<l; i++) {
+        var byteOffset = lines[i].length - byteLength(lines[i]);
         wifis.push({
-            'mac' : lines[i].substr(colMac, colRssi - colMac).trim(),
-            'ssid' : lines[i].substr(0, colMac).trim(),
-            'channel' : lines[i].substr(colChannel, colHt - colChannel).trim(),
-            'signal_level' : lines[i].substr(colRssi, colChannel - colRssi).trim(),
-            'security' : lines[i].substr(colSec).trim()
+            'mac' : lines[i].substr(colMac + byteOffset, colRssi - colMac).trim(),
+            'ssid' : lines[i].substr(0, colMac + byteOffset).trim(),
+            'channel' : lines[i].substr(colChannel + byteOffset, colHt - colChannel).trim(),
+            'signal_level' : lines[i].substr(colRssi + byteOffset, colChannel - colRssi).trim(),
+            'security' : lines[i].substr(colSec + byteOffset).trim()
         });
     }
     wifis.pop();


### PR DESCRIPTION
Using the Airport module on Mac I ran across a network which had an ë in the name. Which indents some lines in the output of airport (because of the double bytes):

```
                            SSID BSSID             RSSI CHANNEL HT CC SECURITY (auth/unicast/group)
                         linksys 00:1e:e5:00:84:9c -89  6       Y  GB NONE
                # WiFi Poëzie # 14:cc:20:f8:9b:d2 -54  11      Y  -- NONE
                       appelboom 28:37:37:43:ee:cc -44  1       Y  NL WPA2(PSK/AES/AES)
```

By counting the actual bytes in the string and comparing that to the string length we can offset the `substr` calls so all info is correct again.